### PR TITLE
Adds some minor tweaks to build-query.js to attempt to fix the 403 errors

### DIFF
--- a/lib/build-query.js
+++ b/lib/build-query.js
@@ -20,12 +20,16 @@ module.exports = function buildQuery({
 
   const defaultHeaders = {
     "Content-Type": "application/json",
+    "Accept": "application/json",
     "X-Request-Id": x_request_id,
-    Authorization: "Bearer " + token
+    Authorization: `Bearer ${token?.trim()}`
   };
 
   const url = `https://api.todoist.com/rest/v2/${endpoint}`;
-  const theHeaders = headers || defaultHeaders;
+  const theHeaders = {
+    ...defaultHeaders, // Ensure base headers are always included
+    ...(headers || {}) // Merge user-provided headers
+  };
   const theMethod = method || "get";
 
   return axios({


### PR DESCRIPTION
A few users have reported errors which suggest that there may be an issue with the token and headers in the requests.

I can't pinpoint anything obvious and I suspect it could be an issue with the scope of their token, perhaps specifically related to GET requests. 

In an effort to rule out issues from the code. I've added a few small tweaks to attempt to sidestep the issues. 

Closes #17 #18 #19 